### PR TITLE
packages_all.sh: better regex

### DIFF
--- a/tests/packages_all.sh
+++ b/tests/packages_all.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
-grep -o "^ \\+[a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
+grep -o "^ \\+[a-zA-Z0-9][a-zA-Z0-9_|-]\\+)" ../has | grep -o "[a-zA-Z0-9_|-]\\+" | tr "|" "\\n" | sort -f
 
 popd >/dev/null


### PR DESCRIPTION
This removes --help, --version, q, h, v from output